### PR TITLE
Remove objectName and material groups from templates

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/index.js
+++ b/src/plugins/recordTypes/collectionobject/forms/index.js
@@ -1,7 +1,11 @@
 import defaultForm from './default';
+import inventoryForm from './inventory';
+import photoForm from './photo';
 
 export default (configContext) => ({
   default: defaultForm(configContext),
+  inventory: inventoryForm(configContext),
+  photo: photoForm(configContext),
   public: {
     disabled: true,
   },

--- a/src/plugins/recordTypes/collectionobject/forms/inventory.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/inventory.jsx
@@ -1,0 +1,119 @@
+import { defineMessages } from 'react-intl';
+
+const template = (configContext) => {
+  const {
+    React,
+  } = configContext.lib;
+
+  const {
+    Col,
+    Panel,
+    Row,
+  } = configContext.layoutComponents;
+
+  const {
+    Field,
+  } = configContext.recordComponents;
+
+  const {
+    extensions,
+  } = configContext.config;
+
+  return (
+    <Field name="document">
+      <Panel name="id" collapsible>
+        <Row>
+          <Col>
+            <Field name="objectNumber" />
+
+            <Field name="otherNumberList">
+              <Field name="otherNumber">
+                <Field name="numberValue" />
+                <Field name="numberType" />
+              </Field>
+            </Field>
+
+            <Field name="inventoryStatusList">
+              <Field name="inventoryStatus" />
+            </Field>
+          </Col>
+
+          <Col>
+            <Field name="briefDescriptions">
+              <Field name="briefDescription" />
+            </Field>
+          </Col>
+        </Row>
+
+        <Field name="titleGroupList">
+          <Field name="titleGroup">
+            <Panel>
+              <Row>
+                <Col>
+                  <Field name="title" />
+                  <Field name="titleLanguage" />
+                </Col>
+
+                <Col>
+                  <Field name="titleType" />
+
+                  <Field name="titleTranslationSubGroupList">
+                    <Field name="titleTranslationSubGroup">
+                      <Field name="titleTranslation" />
+                      <Field name="titleTranslationLanguage" />
+                    </Field>
+                  </Field>
+                </Col>
+              </Row>
+            </Panel>
+          </Field>
+        </Field>
+      </Panel>
+
+      <Panel name="desc" collapsible collapsed>
+        {extensions.dimension.form}
+      </Panel>
+
+      <Panel name="prod" collapsible collapsed>
+        <Row>
+          <Col>
+            <Field name="objectProductionDateGroupList">
+              <Field name="objectProductionDateGroup" />
+            </Field>
+
+            <Field name="objectProductionPersonGroupList">
+              <Field name="objectProductionPersonGroup">
+                <Field name="objectProductionPerson" />
+                <Field name="objectProductionPersonRole" />
+              </Field>
+            </Field>
+          </Col>
+
+          <Col>
+            <Field name="objectProductionOrganizationGroupList">
+              <Field name="objectProductionOrganizationGroup">
+                <Field name="objectProductionOrganization" />
+                <Field name="objectProductionOrganizationRole" />
+              </Field>
+            </Field>
+          </Col>
+        </Row>
+      </Panel>
+
+      <Panel name="hierarchy" collapsible collapsed>
+        <Field name="relation-list-item" subpath="rel:relations-common-list" />
+      </Panel>
+    </Field>
+  );
+};
+
+export default (configContext) => ({
+  messages: defineMessages({
+    name: {
+      id: 'form.collectionobject.inventory.name',
+      defaultMessage: 'Inventory Template',
+    },
+  }),
+  sortOrder: 1,
+  template: template(configContext),
+});

--- a/src/plugins/recordTypes/collectionobject/forms/inventory.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/inventory.jsx
@@ -1,5 +1,3 @@
-import { defineMessages } from 'react-intl';
-
 const template = (configContext) => {
   const {
     React,

--- a/src/plugins/recordTypes/collectionobject/forms/inventory.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/inventory.jsx
@@ -108,12 +108,5 @@ const template = (configContext) => {
 };
 
 export default (configContext) => ({
-  messages: defineMessages({
-    name: {
-      id: 'form.collectionobject.inventory.name',
-      defaultMessage: 'Inventory Template',
-    },
-  }),
-  sortOrder: 1,
   template: template(configContext),
 });

--- a/src/plugins/recordTypes/collectionobject/forms/photo.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/photo.jsx
@@ -247,12 +247,5 @@ const template = (configContext) => {
 };
 
 export default (configContext) => ({
-  messages: defineMessages({
-    name: {
-      id: 'form.collectionobject.photo.name',
-      defaultMessage: 'Photograph Template',
-    },
-  }),
-  sortOrder: 2,
   template: template(configContext),
 });

--- a/src/plugins/recordTypes/collectionobject/forms/photo.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/photo.jsx
@@ -1,5 +1,3 @@
-import { defineMessages } from 'react-intl';
-
 const template = (configContext) => {
   const {
     React,

--- a/src/plugins/recordTypes/collectionobject/forms/photo.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/photo.jsx
@@ -1,0 +1,258 @@
+import { defineMessages } from 'react-intl';
+
+const template = (configContext) => {
+  const {
+    React,
+  } = configContext.lib;
+
+  const {
+    Col,
+    Panel,
+    Row,
+  } = configContext.layoutComponents;
+
+  const {
+    Field,
+  } = configContext.recordComponents;
+
+  const {
+    extensions,
+  } = configContext.config;
+
+  return (
+    <Field name="document">
+      <Panel name="id" collapsible>
+        <Row>
+          <Col>
+            <Field name="objectNumber" />
+
+            <Field name="responsibleDepartments">
+              <Field name="responsibleDepartment" />
+            </Field>
+
+            <Row>
+              <Field name="collection" />
+
+              <Col>
+                <Field name="namedCollections">
+                  <Field name="namedCollection" />
+                </Field>
+              </Col>
+            </Row>
+          </Col>
+
+          <Col>
+            <Field name="briefDescriptions">
+              <Field name="briefDescription" />
+            </Field>
+
+            <Field name="distinguishingFeatures" />
+          </Col>
+        </Row>
+
+        <Field name="titleGroupList">
+          <Field name="titleGroup">
+            <Panel>
+              <Row>
+                <Col>
+                  <Field name="title" />
+                  <Field name="titleLanguage" />
+                </Col>
+
+                <Col>
+                  <Field name="titleType" />
+
+                  <Field name="titleTranslationSubGroupList">
+                    <Field name="titleTranslationSubGroup">
+                      <Field name="titleTranslation" />
+                      <Field name="titleTranslationLanguage" />
+                    </Field>
+                  </Field>
+                </Col>
+              </Row>
+            </Panel>
+          </Field>
+        </Field>
+
+        <Field name="objectCountGroupList">
+          <Field name="objectCountGroup">
+            <Field name="objectCount" />
+            <Field name="objectCountType" />
+            <Field name="objectCountCountedBy" />
+            <Field name="objectCountDate" />
+            <Field name="objectCountNote" />
+          </Field>
+        </Field>
+      </Panel>
+
+      <Panel name="desc" collapsible collapsed>
+        <Row>
+          <Col>
+            <Field name="copyNumber" />
+          </Col>
+
+          <Col>
+            <Field name="editionNumber" />
+
+            <Field name="colors">
+              <Field name="color" />
+            </Field>
+          </Col>
+        </Row>
+
+        <Field name="physicalDescription" />
+
+        <Row>
+          <Field name="technicalAttributeGroupList">
+            <Field name="technicalAttributeGroup">
+              <Field name="technicalAttribute" />
+              <Field name="technicalAttributeMeasurement" />
+              <Field name="technicalAttributeMeasurementUnit" />
+            </Field>
+          </Field>
+
+          <Col />
+        </Row>
+
+        {extensions.dimension.form}
+
+        <Panel name="content" collapsible collapsed>
+          <Field name="contentDescription" />
+
+          <Row>
+            <Col>
+              <Field name="contentLanguages">
+                <Field name="contentLanguage" />
+              </Field>
+
+              <Field name="contentActivities">
+                <Field name="contentActivity" />
+              </Field>
+
+              <Field name="contentConcepts">
+                <Field name="contentConcept" />
+              </Field>
+
+              <Field name="contentDateGroup" />
+
+              <Field name="contentPositions">
+                <Field name="contentPosition" />
+              </Field>
+
+              <Field name="contentObjectGroupList">
+                <Field name="contentObjectGroup">
+                  <Field name="contentObject" />
+                  <Field name="contentObjectType" />
+                </Field>
+              </Field>
+            </Col>
+
+            <Col>
+              <Field name="contentPeoples">
+                <Field name="contentPeople" />
+              </Field>
+
+              <Field name="contentPersons">
+                <Field name="contentPerson" />
+              </Field>
+
+              <Field name="contentPlaces">
+                <Field name="contentPlace" />
+              </Field>
+
+              <Field name="contentScripts">
+                <Field name="contentScript" />
+              </Field>
+
+              <Field name="contentOrganizations">
+                <Field name="contentOrganization" />
+              </Field>
+
+              <Field name="contentEventNameGroupList">
+                <Field name="contentEventNameGroup">
+                  <Field name="contentEventName" />
+                  <Field name="contentEventNameType" />
+                </Field>
+              </Field>
+
+              <Field name="contentOtherGroupList">
+                <Field name="contentOtherGroup">
+                  <Field name="contentOther" />
+                  <Field name="contentOtherType" />
+                </Field>
+              </Field>
+            </Col>
+          </Row>
+
+          <Field name="contentNote" />
+        </Panel>
+      </Panel>
+
+      <Panel name="prod" collapsible collapsed>
+        <Row>
+          <Col>
+            <Field name="objectProductionDateGroupList">
+              <Field name="objectProductionDateGroup" />
+            </Field>
+
+            <Field name="techniqueGroupList">
+              <Field name="techniqueGroup">
+                <Field name="technique" />
+                <Field name="techniqueType" />
+              </Field>
+            </Field>
+
+            <Field name="objectProductionPlaceGroupList">
+              <Field name="objectProductionPlaceGroup">
+                <Field name="objectProductionPlace" />
+                <Field name="objectProductionPlaceRole" />
+              </Field>
+            </Field>
+          </Col>
+
+          <Col>
+            <Field name="objectProductionPersonGroupList">
+              <Field name="objectProductionPersonGroup">
+                <Field name="objectProductionPerson" />
+                <Field name="objectProductionPersonRole" />
+              </Field>
+            </Field>
+
+            <Field name="objectProductionOrganizationGroupList">
+              <Field name="objectProductionOrganizationGroup">
+                <Field name="objectProductionOrganization" />
+                <Field name="objectProductionOrganizationRole" />
+              </Field>
+            </Field>
+
+            <Field name="objectProductionNote" />
+          </Col>
+        </Row>
+      </Panel>
+
+      <Panel name="reference" collapsible collapsed>
+        <Field name="referenceGroupList">
+          <Field name="referenceGroup">
+            <Field name="reference" />
+            <Field name="referenceNote" />
+          </Field>
+        </Field>
+      </Panel>
+
+      <Panel name="hierarchy" collapsible collapsed>
+        <Field name="relation-list-item" subpath="rel:relations-common-list" />
+      </Panel>
+    </Field>
+  );
+};
+
+export default (configContext) => ({
+  messages: defineMessages({
+    name: {
+      id: 'form.collectionobject.photo.name',
+      defaultMessage: 'Photograph Template',
+    },
+  }),
+  sortOrder: 2,
+  template: template(configContext),
+});


### PR DESCRIPTION
**What does this do?**
Removes objectName and material groups from collectionobject templates

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1403

These fields were added to the templates for the core profile but aren't used in herbarium and needed to be removed.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Create a collectionobject
  * On the photo template, see that objectName and material groups do not exist
  * On the inventory template, see that the objectName group does not exist
* If wanted, a sanity check can also be done w/ git to compare the templates vs their cspace-ui defaults
```
git diff --no-index  ${CSPACE_UI}/src/plugins/recordTypes/collectionobject/forms/inventory.jsx src/plugins/recordTypes/collectionobject/forms/inventory.jsx
git diff --no-index  ${CSPACE_UI}/src/plugins/recordTypes/collectionobject/forms/photo.jsx src/plugins/recordTypes/collectionobject/forms/photo.jsx
```  

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally