### PR TITLE
DRYD-1506: Add published related links

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -313,6 +313,13 @@ const template = (configContext) => {
             <Field name="referenceNote" />
           </Field>
         </Field>
+
+        <Field name="publishedRelatedLinkGroupList">
+          <Field name="publishedRelatedLinkGroup">
+            <Field name="relatedLink" />
+            <Field name="descriptiveTitle" />
+          </Field>
+        </Field>
       </Panel>
 
       <Panel name="collect" collapsible collapsed>

--- a/src/plugins/recordTypes/collectionobject/forms/photo.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/photo.jsx
@@ -235,6 +235,13 @@ const template = (configContext) => {
             <Field name="referenceNote" />
           </Field>
         </Field>
+
+        <Field name="publishedRelatedLinkGroupList">
+          <Field name="publishedRelatedLinkGroup">
+            <Field name="relatedLink" />
+            <Field name="descriptiveTitle" />
+          </Field>
+        </Field>
       </Panel>
 
       <Panel name="hierarchy" collapsible collapsed>


### PR DESCRIPTION
**What does this do?**
* Add publishedRelatedLinkGroup to forms

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1506

The `publishedRelatedLinkGroupList` was added to core and is now being added to profiles which can use it.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver `npm run devserver --back-end=https://herbarium.dev.collectionspace.org`
* Create a collectionobject
* View the `Reference Information` section and see that the published links 

**Dependencies for merging? Releasing to production?**
I wasn't entirely sure of which templates to add this to for all profiles. It was added to default and photo here as they both have the reference section. The public template is disabled so it was skipped.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested using herbarium.dev as a backend