### PR TITLE
Change package version to 2.1.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cspace-ui-plugin-profile-herbarium",
-  "version": "2.0.13",
+  "version": "2.1.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cspace-ui-plugin-profile-herbarium",
-      "version": "2.0.13",
+      "version": "2.1.0-rc.1",
       "license": "ECL-2.0",
       "dependencies": {
         "cspace-ui-plugin-ext-naturalhistory": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui-plugin-profile-herbarium",
-  "version": "2.0.13",
+  "version": "2.1.0-rc.1",
   "description": "Herbarium profile plugin for the CollectionSpace UI",
   "author": "",
   "license": "ECL-2.0",


### PR DESCRIPTION
**What does this do?**
* Updates package version to 2.1.0-rc.1

**Why are we doing this? (with JIRA link)**
Herbarium had an update to the template which I forgot to merge, so this is getting an updated minor version.

**How should this be tested? Do these changes have associated tests?**
-

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested w/ herbarium.dev as a backend