### PR TITLE
DRYD-1611: Remove objectCountGroup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "chai-as-promised": "^5.3.0",
         "chai-immutable": "^1.6.0",
         "cross-env": "^2.0.0",
-        "cspace-ui": "^9.0.0",
+        "cspace-ui": "^10.0.0-rc.1",
         "css-loader": "^6.7.3",
         "eslint": "^6.7.2",
         "eslint-config-airbnb": "^18.0.1",
@@ -3059,9 +3059,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -3070,9 +3070,9 @@
       }
     },
     "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
       "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -4052,9 +4052,9 @@
       }
     },
     "node_modules/cspace-client": {
-      "version": "2.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/cspace-client/-/cspace-client-2.0.0-rc.3.tgz",
-      "integrity": "sha512-yxfZu4lTbyKn/Fom8VBCnU3mJO5bzxQZRKfq+EZcGIsO4uA7DJ9X6kro7IqdQ58QlAUZV1ccCZmFzc+FwE7pkQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cspace-client/-/cspace-client-2.0.0.tgz",
+      "integrity": "sha512-l8+bCis2JZmVhEsv0xGC5Tl7/AMtrr7yS1J+fXpCh8k/7vxHiOsTDXkGwyWNbKQhAyBQ6OR98upqANDuUtc7Ww==",
       "dev": true,
       "dependencies": {
         "cspace-api": "^1.0.8",
@@ -4083,9 +4083,9 @@
       }
     },
     "node_modules/cspace-layout": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/cspace-layout/-/cspace-layout-2.0.3.tgz",
-      "integrity": "sha512-FMC1pub6pm8hHnp/NKlnngugdmmP6vqGmMCSQgyPe4ebetqZEPwDSdxDXmX8K7k8vErGrOY1t28NOQNBOymi2A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/cspace-layout/-/cspace-layout-2.0.4.tgz",
+      "integrity": "sha512-xfPppMXp0EWfi19TLS7dhN4BVPgDImqaf0jZRNbllavIIZWGlDvQ9sFYmT0x7HU+0Y1S7KRdrxbY+NlaeeqdmQ==",
       "dev": true,
       "dependencies": {
         "classnames": "^2.2.6",
@@ -4103,15 +4103,15 @@
       "dev": true
     },
     "node_modules/cspace-ui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cspace-ui/-/cspace-ui-9.0.0.tgz",
-      "integrity": "sha512-vEKRGMM21R8RghGup1LhT/C7z/uYWUgm87waWhwtl8gi/2NernoQYs8bv6QfxBBtor2vVR8KNQAc6JZn4ULeew==",
+      "version": "10.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/cspace-ui/-/cspace-ui-10.0.0-rc.1.tgz",
+      "integrity": "sha512-hqbbdFPXCrSnDPVPxfEclFe0vjcqlJAxl0HU8U7OgdH5D6LgZ/mGO6T1M+AwIpk82AoaLvAPxHHgPBASgXZS1g==",
       "dev": true,
       "dependencies": {
         "classnames": "^2.2.5",
-        "cspace-client": "^2.0.0-rc.2",
+        "cspace-client": "^2.0.0",
         "cspace-input": "^2.0.4",
-        "cspace-layout": "^2.0.2",
+        "cspace-layout": "^2.0.4",
         "cspace-refname": "^1.0.4",
         "history": "^5.0.0",
         "immutable": "^3.8.2",
@@ -5941,14 +5941,15 @@
       "dev": true
     },
     "node_modules/form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.2.tgz",
+      "integrity": "sha512-GgwY0PS7DbXqajuGf4OYlsrIu3zgxD6Vvql43IBhm6MahqA5SK/7mwhtNj2AdH2z35YR34ujJ7BN+3fFC3jP5Q==",
       "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "^2.1.12",
+        "safe-buffer": "^5.2.1"
       },
       "engines": {
         "node": ">= 0.12"
@@ -9971,9 +9972,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
-      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dev": true,
       "dependencies": {
         "side-channel": "^1.0.6"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "chai-as-promised": "^5.3.0",
     "chai-immutable": "^1.6.0",
     "cross-env": "^2.0.0",
-    "cspace-ui": "^9.0.0",
+    "cspace-ui": "^10.0.0-rc.1",
     "css-loader": "^6.7.3",
     "eslint": "^6.7.2",
     "eslint-config-airbnb": "^18.0.1",

--- a/src/plugins/recordTypes/collectionobject/forms/photo.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/photo.jsx
@@ -71,16 +71,6 @@ const template = (configContext) => {
             </Panel>
           </Field>
         </Field>
-
-        <Field name="objectCountGroupList">
-          <Field name="objectCountGroup">
-            <Field name="objectCount" />
-            <Field name="objectCountType" />
-            <Field name="objectCountCountedBy" />
-            <Field name="objectCountDate" />
-            <Field name="objectCountNote" />
-          </Field>
-        </Field>
       </Panel>
 
       <Panel name="desc" collapsible collapsed>


### PR DESCRIPTION
**What does this do?**
* Removes objectCountGroup
* Update cspace-ui dev dependency 

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1611

As part of our data QA process we flagged objectCountUnit as needing to be added to a few profiles. However for herbarium, we realized that objectCountGroup only existed on a single template and weren't sure if it should be included in the profile. The result of our discussion was that we can remove it from the photo template.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver with dev as a backend
* Check that the photo template does not include objectCountGroup in the `Object Identification Information` section

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested using herbarium.dev as a backend